### PR TITLE
removed Level 7+ from selection on page 2

### DIFF
--- a/R/read_data.R
+++ b/R/read_data.R
@@ -81,7 +81,7 @@ region_v2 <- qualifications %>%
   distinct(Region, .keep_all = F) %>%
   unlist(use.names = F)
 
-level_v2 <- c("Level 2", "Level 3", "Level 4/5", "Level 6", "Level 7+")
+level_v2 <- c("Level 2", "Level 3", "Level 4/5", "Level 6")
 
 # download data -----------------------------------------------------------
 


### PR DESCRIPTION
## Pull request overview

this removes Level 7+ from choices

## Pull request checklist

Please check if your PR fulfils the following:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been run locally and are passing (`run_tests_locally()`)
- [x] Code is styled according to tidyverse styling (checked locally with `tidy_code()`)


## What is the current behaviour?

pathways for Level 7+ do not exist, it makes sense to remove it - it causes issues for colors on stacked chart on page 2


## What is the new behaviour?

selection only for levels 2-6 on second pate
