### PR TITLE
Update accessibility (issue #22)

### DIFF
--- a/R/accessibility_statement.R
+++ b/R/accessibility_statement.R
@@ -1,7 +1,7 @@
 accessibility_statement <- function() {
   div(
-    h2("Accessibility statement for LEO Graduate Industry dashboard"),
-    "This accessibility statement applies to the Longitudinal Education Outcomes (LEO) graduate industry dashboard.",
+    h2("Accessibility statement for career pathways dashboard"),
+    "This accessibility statement applies to the career pathways: post-16 qualifications held by employees dashboard.",
     "This application is run by the Department for Education. We want as many people as possible to be able to use this application,
             and have actively developed this application with accessibilty in mind.",
     br(),

--- a/R/accessibility_statement.R
+++ b/R/accessibility_statement.R
@@ -40,7 +40,7 @@ accessibility_statement <- function() {
     "Department for Education is committed to making its website accessible, in accordance with the Public Sector Bodies
       (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.",
     h3("Preparation of this accessibility statement"),
-    "This statement was prepared on 19th May 2022 and this website was last tested on 19th May 2022. The test was carried out by the Department for Education.", # TODO: Add date
+    "This statement was prepared on 19th May 2022 and this website was last tested on 19th May 2022 in advance of publication on 25th May 2022. The test was carried out by the Department for Education.", # TODO: Add date
     br(),
     br(),
   )

--- a/R/accessibility_statement.R
+++ b/R/accessibility_statement.R
@@ -1,6 +1,6 @@
 accessibility_statement <- function() {
   div(
-    h2("Accessibility statement for career pathways dashboard"),
+    h2("Accessibility statement for the Career Pathways: post-16 qualifications held by employees dashboard"),
     "This accessibility statement applies to the Career Pathways: post-16 qualifications held by employees dashboard.",
     "This application is run by the Department for Education. We want as many people as possible to be able to use this application,
             and have actively developed this application with accessibilty in mind.",
@@ -14,20 +14,21 @@ accessibility_statement <- function() {
     ". This means that this application:",
     br(),
     tags$div(tags$ul(
-      tags$li("uses colours that have sufficient contrast"),
-      tags$li("allows you to zoom in up to 300% without the text spilling off the screen"),
-      tags$li("has its performance regularly monitored, with a team working on any feedback to improve accessibility for all users")
+      tags$li("uses colours that have sufficient contrast;"),
+      tags$li("allows you to zoom in up to 300% without the text spilling off the screen;"),
+      tags$li("navigate most of the website using just a keyboard;"),
+      tags$li("has its performance regularly monitored, with a team working on any feedback to improve accessibility for all users.")
     )), # TODO: UPDATE THESE BULLET POINTS
     "We've also made the website text as simple as possible to understand.",
     a(href = "https://mcmw.abilitynet.org.uk/", "AbilityNet", .noWS = c("after")),
-    " has advice on making your device easier to use if you have a disability.",
+    " has advice on making your device easier to use if you have a disability. We have trialled this website with multiple screen-reader software (Edge: Read aloud, ChromeVox and Pericles) and made adjustments to optimise their performace where feasible.",
     h3("How accessible this website is"),
     "We recognise that there are still potential issues with accessibility in this application, but we will continue
            to review updates to technology available to us to keep improving accessibility for all of our users. For example, these
            are known issues that we will continue to monitor and improve:",
     tags$div(tags$ul(
-      tags$li("Keyboard navigation through the interactive charts is currently limited"),
-      tags$li("Alternative text in interactive charts is limited to titles and could be more descriptive (although this data is available in csv format)")
+      tags$li("Keyboard navigation through the interactive charts is currently limited, and some features are unavailable for keyboard only users;"),
+      tags$li("Alternative text in interactive charts is limited to titles and could be more descriptive (although this data is available in csv format).")
     )), # TODO: UPDATE THESE BULLET POINTS
 
     h3("Feedback and contact information"),
@@ -35,26 +36,12 @@ accessibility_statement <- function() {
       if you have any feedback on how we could further improve the accessibility of this application, please contact us at ",
     a(href = "mailto:ufs.contact@education.gov.uk", "ufs.contact@education.gov.uk", .noWS = c("after")),
     ".",
-    br(),
-    br(),
     h3("Technical information about this website’s accessibility"),
     "Department for Education is committed to making its website accessible, in accordance with the Public Sector Bodies
       (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.",
-    h4("Compliance status"),
-    "This website is partially compliant with the ",
-    a(href = "https://www.w3.org/TR/WCAG21/", "Web Content Accessibility Guidelines version 2.1", .noWS = c("after")),
-    " AA standard, due to [insert one of the following: ‘the non-compliances’, ‘the exemptions’ or ‘the non-compliances and exemptions’] listed below.",
-    br(),
-    br(),
-    "List of any non-compliances", # TODO: List the non-compliances using the appropriate template
-
     h3("Preparation of this accessibility statement"),
-    "This statement was prepared on 24th May 2022.", # TODO: Add date
+    "This statement was prepared on 19th May 2022 and this website was last tested on 19th May 2022. The test was carried out by the Department for Education.", # TODO: Add date
     br(),
     br(),
-    "This website was last tested on 18th May 2022. The test was carried out by Department for Education.", # TODO: Add date
-    br(),
-    br(),
-    br()
   )
 }

--- a/R/accessibility_statement.R
+++ b/R/accessibility_statement.R
@@ -1,7 +1,7 @@
 accessibility_statement <- function() {
   div(
     h2("Accessibility statement for career pathways dashboard"),
-    "This accessibility statement applies to the career pathways: post-16 qualifications held by employees dashboard.",
+    "This accessibility statement applies to the Career Pathways: post-16 qualifications held by employees dashboard.",
     "This application is run by the Department for Education. We want as many people as possible to be able to use this application,
             and have actively developed this application with accessibilty in mind.",
     br(),
@@ -49,10 +49,10 @@ accessibility_statement <- function() {
     "List of any non-compliances", # TODO: List the non-compliances using the appropriate template
 
     h3("Preparation of this accessibility statement"),
-    "This statement was prepared on [date when it was first published].", # TODO: Add date
+    "This statement was prepared on 24th May 2022.", # TODO: Add date
     br(),
     br(),
-    "This website was last tested on [date]. The test was carried out by Department for Education.", # TODO: Add date
+    "This website was last tested on 18th May 2022. The test was carried out by Department for Education.", # TODO: Add date
     br(),
     br(),
     br()

--- a/R/dashboard_text.R
+++ b/R/dashboard_text.R
@@ -10,8 +10,8 @@ welcome_text <- function() {
     br(),
     "The data in the career pathways dashboard aims to use this development to:",
     tags$ul(
-      tags$li("Explore how LEO can help us to understand the education pathways of employees in different industry sectors"),
-      tags$li("Demonstrate how LEO data could be used to develop a careers information tool via an interactive dashboard")
+      tags$li("Explore how LEO can help us to understand the education pathways of employees in different industry sectors;"),
+      tags$li("Demonstrate how LEO data could be used to develop a careers information tool via an interactive dashboard.")
     ),
     "This dashboard has been produced to support the aims of the ",
     a(

--- a/server.R
+++ b/server.R
@@ -7,7 +7,7 @@ server <- function(input, output, session) {
 
   # Close session after closing app --------------------------
 
-  session$onSessionEnded(stopApp) # commenting out to test using lighthouse
+#  session$onSessionEnded(stopApp) # commenting out to test using lighthouse
 
   # Links to tabs --------------------------------------------
 

--- a/ui.R
+++ b/ui.R
@@ -1,12 +1,12 @@
-#library(shinya11y)
+# library(shinya11y)
 
 fluidPage(
-#  use_tota11y(),
+  #  use_tota11y(),
   shinyjs::useShinyjs(),
   includeCSS("www/dfe_shiny_gov_style.css"),
   title = "Unit for Future Skills - Career Explorer Dashboard",
 
-  
+
 
   # Set metadata for browser ===============================================================
 

--- a/ui.R
+++ b/ui.R
@@ -1,11 +1,12 @@
-
+#library(shinya11y)
 
 fluidPage(
+#  use_tota11y(),
   shinyjs::useShinyjs(),
   includeCSS("www/dfe_shiny_gov_style.css"),
   title = "Unit for Future Skills - Career Explorer Dashboard",
 
-
+  
 
   # Set metadata for browser ===============================================================
 
@@ -220,7 +221,7 @@ fluidPage(
               id = "second",
               align = "left",
               width = 3,
-              style = "height:15vh; padding:5px; word-wrap: break-word;",
+              style = "height:15vh; min-height:96px; padding:5px; word-wrap: break-word;",
               uiOutput("perc_in_sector"),
               uiOutput("kpiSector")
             ),
@@ -232,7 +233,7 @@ fluidPage(
               id = "first",
               align = "left",
               width = 3,
-              style = "height:15vh; padding:5px; word-wrap: break-word;",
+              style = "height:15vh; min-height:96px; padding:5px; word-wrap: break-word;",
               uiOutput("median_in_sector"),
               tags$b("Annual average earnings",
                 style = "font-size: 12px; color: #ffffff"
@@ -246,7 +247,7 @@ fluidPage(
               id = "second",
               align = "left",
               width = 3,
-              style = "height:15vh; padding:5px; word-wrap: break-word;",
+              style = "height:15vh; min-height:96px; padding:5px; word-wrap: break-word;",
               uiOutput("directionSector"),
               uiOutput("kpiChange")
             ),
@@ -427,7 +428,7 @@ fluidPage(
                           in the tax year 2018-19.
                           Click on the qualification names to expand the chart and explore different pathways to higher level qualifications.
                           In the tooltip, the leaf count shows how many different qualification end points can be reached by expanding the chart.
-                           Please note that this it is not a complete list.", style = "font-size: 16px; font-style: italic;"),
+                          Please note that this it is not a complete list.", style = 'font-size: 16px; font-style: italic;'),
           br(),
           uiOutput("svglegend"),
           box(width = 12, collapsibleTreeOutput("treePlot"))
@@ -439,7 +440,7 @@ fluidPage(
 
     tabPanel(
       "Accessibility",
-      warning_text(inputId = "accessWarn", text = "THIS IS A DRAFT STATEMENT - NEEDS UPDATING AFTER TESTING"),
+      # warning_text(inputId = "accessWarn", text = "THIS IS A DRAFT STATEMENT - NEEDS UPDATING AFTER TESTING"),
       accessibility_statement() # defined in R/accessibility_statement.R
     ),
 

--- a/www/dfe_shiny_gov_style.css
+++ b/www/dfe_shiny_gov_style.css
@@ -25,7 +25,7 @@
 .navbar-default .navbar-nav>.active>a, .navbar-default .navbar-nav>.active>a:focus, .navbar-default .navbar-nav>li>a:hover {
     color: #ffffff;
     background-color:	#505a5f;
-     font-size: 20px;
+     font-size: 18px;
 }
 
 .well {


### PR DESCRIPTION
Ran a range of accessibility testing (#22) on the dashboard using Lighthouse, shinya11y and a variety of screenreaders (Edge: Read aloud, ChromeVox and Pericles).

### Screen reading
Screen readers were running through lists too quickly, so added some punctuation (;) at the end of each list item in any list.

### Lighthouse
Lighthouse passed without issues (one previous issue with an empty link was dealt with in an earlier PR).

### Shinya11y
Contrast checks out fine with no issues.

![shinya11y_contrast](https://user-images.githubusercontent.com/230859/169104165-8686db6c-884c-4c8f-a477-f36270a57f0d.JPG)

![shinya11y_contrast_tab2](https://user-images.githubusercontent.com/230859/169104175-6ac6830c-03bd-4047-af0e-973090e56a26.JPG)
No obvious issues flagged.

### Other tests
The 300% zoom showed up some issues with text going missing in the valuebox-style elements. Fixed this by placing a min-height limit in the styling for each element.
Images below show the before and after.

![Max-zoom_value-boxes_glitch](https://user-images.githubusercontent.com/230859/169104535-6657881f-1e94-4601-b485-f061cbeb7506.JPG) 

![Max-zoom_value-boxes_unglitched](https://user-images.githubusercontent.com/230859/169104647-a863c1da-dc08-432e-ad53-4d301bde4aa9.JPG)

