### PR TITLE
fixed title for top20 quals and chart section

### DIFF
--- a/R/dashboard_text.R
+++ b/R/dashboard_text.R
@@ -87,7 +87,14 @@ qualification type and the JACs principal subject code.",
     employees in full time and part time employment. The median earnings in this
     dashboard are presented as raw figures. They do not seek to control for
     differences in employee characteristics that may influence earnings over
-    time or across different employee populations."
+    time or across different employee populations.",     br(), br(), 
+    tags$h4("Rounding and suppression"),
+    "Employee numbers are rounded to the nearest 10, annual median earnings are rounded to 
+    the nearest 100 and percentages are provided to the nearest one decimal place. 
+    Figures have been suppressed with the value ‘u’ for annual earnings based on fewer than 10
+    employees and ‘c’ for percentages where the numerator is less than 3 or the denominator is
+    less than 6. Employee numbers below 5 are replaced with ‘low.’ 
+    Suppressed figures have been removed from charts and tables."
   )
 }
 

--- a/R/dashboard_text.R
+++ b/R/dashboard_text.R
@@ -87,13 +87,13 @@ qualification type and the JACs principal subject code.",
     employees in full time and part time employment. The median earnings in this
     dashboard are presented as raw figures. They do not seek to control for
     differences in employee characteristics that may influence earnings over
-    time or across different employee populations.",     br(), br(), 
+    time or across different employee populations.", br(), br(),
     tags$h4("Rounding and suppression"),
-    "Employee numbers are rounded to the nearest 10, annual median earnings are rounded to 
-    the nearest 100 and percentages are provided to the nearest one decimal place. 
+    "Employee numbers are rounded to the nearest 10, annual median earnings are rounded to
+    the nearest 100 and percentages are provided to the nearest one decimal place.
     Figures have been suppressed with the value ‘u’ for annual earnings based on fewer than 10
     employees and ‘c’ for percentages where the numerator is less than 3 or the denominator is
-    less than 6. Employee numbers below 5 are replaced with ‘low.’ 
+    less than 6. Employee numbers below 5 are replaced with ‘low.’
     Suppressed figures have been removed from charts and tables."
   )
 }

--- a/server.R
+++ b/server.R
@@ -713,7 +713,9 @@ server <- function(input, output, session) {
 
 
   # Page 1&2: reactive Box & KPIs titles --------------------------------------------------------------
-
+ 
+ `%notin%` <- Negate(`%in%`)
+  
   # page titles
   output$page1title <- renderUI({
     if (input$region %in% c("England", "Yorkshire and The Humber")) {
@@ -825,6 +827,8 @@ server <- function(input, output, session) {
 
   # page 1: subject chart and qualification table
   output$box3title <- renderText({
+    validate(need(input$inSelect %notin% c("", NA), 
+                  "Subject and qualification choices for employees"))
     HTML(
       paste0(
         "Subject and qualification choices for employees at ", tolower(input$inSelect),

--- a/server.R
+++ b/server.R
@@ -713,9 +713,9 @@ server <- function(input, output, session) {
 
 
   # Page 1&2: reactive Box & KPIs titles --------------------------------------------------------------
- 
- `%notin%` <- Negate(`%in%`)
-  
+
+  `%notin%` <- Negate(`%in%`)
+
   # page titles
   output$page1title <- renderUI({
     if (input$region %in% c("England", "Yorkshire and The Humber")) {
@@ -827,8 +827,10 @@ server <- function(input, output, session) {
 
   # page 1: subject chart and qualification table
   output$box3title <- renderText({
-    validate(need(input$inSelect %notin% c("", NA), 
-                  "Subject and qualification choices for employees"))
+    validate(need(
+      input$inSelect %notin% c("", NA),
+      "Subject and qualification choices for employees"
+    ))
     HTML(
       paste0(
         "Subject and qualification choices for employees at ", tolower(input$inSelect),

--- a/tests/shinytest/testUI-expected/career-pathways_10.json
+++ b/tests/shinytest/testUI-expected/career-pathways_10.json
@@ -11,7 +11,14 @@
   },
   "output": {
     "box2title": "Employee earnings by industry sub-sector and highest level of education",
-    "box3title": "Subject and qualification choices for employees at  working in all sub-sectors",
+    "box3title": {
+      "message": "Subject and qualification choices for employees",
+      "call": "NULL",
+      "type": [
+        "shiny.silent.error",
+        "validation"
+      ]
+    },
     "box4title": "Post-16 qualification pathways starting at  level 3",
     "box7title": "15.2% of employees have a highest qualification at level 3",
     "directionSector": {

--- a/tests/shinytest/testUI-expected/career-pathways_11.json
+++ b/tests/shinytest/testUI-expected/career-pathways_11.json
@@ -11,7 +11,14 @@
   },
   "output": {
     "box2title": "Employee earnings by industry sub-sector and highest level of education",
-    "box3title": "Subject and qualification choices for employees at  working in all sub-sectors",
+    "box3title": {
+      "message": "Subject and qualification choices for employees",
+      "call": "NULL",
+      "type": [
+        "shiny.silent.error",
+        "validation"
+      ]
+    },
     "box4title": "Post-16 qualification pathways starting at  level 3",
     "box7title": "15.2% of employees have a highest qualification at level 3",
     "directionSector": {

--- a/tests/shinytest/testUI-expected/career-pathways_12.json
+++ b/tests/shinytest/testUI-expected/career-pathways_12.json
@@ -11,7 +11,14 @@
   },
   "output": {
     "box2title": "Employee earnings by industry sub-sector and highest level of education",
-    "box3title": "Subject and qualification choices for employees at  working in all sub-sectors",
+    "box3title": {
+      "message": "Subject and qualification choices for employees",
+      "call": "NULL",
+      "type": [
+        "shiny.silent.error",
+        "validation"
+      ]
+    },
     "box4title": "Post-16 qualification pathways starting at  level 3",
     "box7title": "15.2% of employees have a highest qualification at level 3",
     "directionSector": {

--- a/tests/shinytest/testUI-expected/career-pathways_6.json
+++ b/tests/shinytest/testUI-expected/career-pathways_6.json
@@ -11,7 +11,14 @@
   },
   "output": {
     "box2title": "Employee earnings by industry sub-sector and highest level of education",
-    "box3title": "Subject and qualification choices for employees at  working in all sub-sectors",
+    "box3title": {
+      "message": "Subject and qualification choices for employees",
+      "call": "NULL",
+      "type": [
+        "shiny.silent.error",
+        "validation"
+      ]
+    },
     "directionSector": {
       "html": "<b style=\"font-size:36px; text-align:center; color:\t#ffffff\">0.2%<\/b>",
       "deps": [

--- a/tests/shinytest/testUI-expected/career-pathways_7.json
+++ b/tests/shinytest/testUI-expected/career-pathways_7.json
@@ -11,7 +11,14 @@
   },
   "output": {
     "box2title": "Employee earnings by industry sub-sector and highest level of education",
-    "box3title": "Subject and qualification choices for employees at  working in all sub-sectors",
+    "box3title": {
+      "message": "Subject and qualification choices for employees",
+      "call": "NULL",
+      "type": [
+        "shiny.silent.error",
+        "validation"
+      ]
+    },
     "box4title": "Post-16 qualification pathways starting at  level 2",
     "box7title": "58.9% of employees have a highest qualification at level 2",
     "directionSector": {

--- a/tests/shinytest/testUI-expected/career-pathways_8.json
+++ b/tests/shinytest/testUI-expected/career-pathways_8.json
@@ -11,7 +11,14 @@
   },
   "output": {
     "box2title": "Employee earnings by industry sub-sector and highest level of education",
-    "box3title": "Subject and qualification choices for employees at  working in all sub-sectors",
+    "box3title": {
+      "message": "Subject and qualification choices for employees",
+      "call": "NULL",
+      "type": [
+        "shiny.silent.error",
+        "validation"
+      ]
+    },
     "box4title": "Post-16 qualification pathways starting at  level 2",
     "box7title": "30.7% of employees have a highest qualification at level 2",
     "directionSector": {

--- a/tests/shinytest/testUI-expected/career-pathways_9.json
+++ b/tests/shinytest/testUI-expected/career-pathways_9.json
@@ -11,7 +11,14 @@
   },
   "output": {
     "box2title": "Employee earnings by industry sub-sector and highest level of education",
-    "box3title": "Subject and qualification choices for employees at  working in all sub-sectors",
+    "box3title": {
+      "message": "Subject and qualification choices for employees",
+      "call": "NULL",
+      "type": [
+        "shiny.silent.error",
+        "validation"
+      ]
+    },
     "box4title": {
       "message": "subscript out of bounds",
       "call": "s$Level[[1]]",

--- a/ui.R
+++ b/ui.R
@@ -325,7 +325,7 @@ fluidPage(
                     Select the ‘Subject area of highest qualification’ tab for a breakdown of the subject areas of employees’ highest qualifications and their average earnings.
                     Charts can be filtered by qualification level and sub-sector using the drop down selectors in the side panel.
                     The table displays up to 20 qualifications, ordered by the number of employees who hold them.
-                    Qualifications with small numbers of employees are not included in this table, which means some selections result in a table with fewer than 20 qualifications."
+                    Qualifications with small numbers of employees are not included in this table, which means some selections result in a table with no data fewer than 20 qualifications."
                   ),
                   DT::dataTableOutput("hqSubTable")
                 ),
@@ -339,7 +339,7 @@ fluidPage(
                     Select the ‘Subject area of highest qualification’ tab for a breakdown of the subject areas of employees’ highest qualifications and their average earnings.
                     Charts can be filtered by qualification level and sub-sector using the drop down selectors in the side panel.
                     The table displays up to 20 qualifications, ordered by the number of employees who hold them.
-                    Qualifications with small numbers of employees are not included in this table, which means some selections result in a table with fewer than 20 qualifications."
+                    Qualifications with small numbers of employees are not included in this table, which means some selections result in a table with no data fewer than 20 qualifications."
                   ),
                   div(plotlyOutput("indSubChart"), align = "center")
                 )


### PR DESCRIPTION
## Pull request overview

Title "Subject and qualification choices for employees at ... working in ...." on page 1 has 2 interactive elements: sub-sector and qualification level which are input vars for select boxes. Some subsectors like mining and quarrying or agriculture have small values which could be suppressed from chart/table and there is no qual level so the title needs to be adjusted to accommodate this situation when no data is available and no input variable appears in select box. 

## Pull request checklist

Please check if your PR fulfils the following:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been run locally and are passing (`run_tests_locally()`)
- [x] Code is styled according to tidyverse styling (checked locally with `tidy_code()`)


## What is the current behaviour?

Currently the title shows no values for interactive elements, which makes it incomplete and it reads wrong.   

## What is the new behaviour?

The title changes to a standard text with no interactive elements when data is not available for table / charts. 

## Anything else

This PR also add a section on rounding and suppression in homepage and some additional words in help_text() for no availability of data. 
