### PR TITLE
Replace use of conditionalPanel function

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.1.2",
+    "Version": "4.1.3",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -59,10 +59,10 @@
     },
     "MASS": {
       "Package": "MASS",
-      "Version": "7.3-56",
+      "Version": "7.3-57",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "af0e1955cb80bb36b7988cc657db261e",
+      "Hash": "71476c1d88d1ebdf31580e5a257d5d31",
       "Requirements": []
     },
     "Matrix": {
@@ -311,6 +311,14 @@
       "Hash": "0baa960e3b49c6176a4f42addcbacc59",
       "Requirements": []
     },
+    "brew": {
+      "Package": "brew",
+      "Version": "1.0-7",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "38875ea52350ff4b4c03849fc69736c8",
+      "Requirements": []
+    },
     "brio": {
       "Package": "brio",
       "Version": "1.1.3",
@@ -378,10 +386,10 @@
     },
     "cli": {
       "Package": "cli",
-      "Version": "3.2.0",
+      "Version": "3.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "1bdb126893e9ce6aae50ad1d6fc32faf",
+      "Hash": "23abf173c2b783dcc43379ab9bba00ee",
       "Requirements": [
         "glue"
       ]
@@ -453,6 +461,20 @@
       "Hash": "8dc45fd8a1ee067a92b85ef274e66d6a",
       "Requirements": []
     },
+    "credentials": {
+      "Package": "credentials",
+      "Version": "1.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "93762d0a34d78e6a025efdbfb5c6bb41",
+      "Requirements": [
+        "askpass",
+        "curl",
+        "jsonlite",
+        "openssl",
+        "sys"
+      ]
+    },
     "crosstalk": {
       "Package": "crosstalk",
       "Version": "1.2.0",
@@ -515,6 +537,35 @@
         "rprojroot"
       ]
     },
+    "devtools": {
+      "Package": "devtools",
+      "Version": "2.4.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "fc35e13bb582e5fe6f63f3d647a4cbe5",
+      "Requirements": [
+        "callr",
+        "cli",
+        "desc",
+        "ellipsis",
+        "fs",
+        "httr",
+        "lifecycle",
+        "memoise",
+        "pkgbuild",
+        "pkgload",
+        "rcmdcheck",
+        "remotes",
+        "rlang",
+        "roxygen2",
+        "rstudioapi",
+        "rversions",
+        "sessioninfo",
+        "testthat",
+        "usethis",
+        "withr"
+      ]
+    },
     "diffobj": {
       "Package": "diffobj",
       "Version": "0.3.5",
@@ -535,10 +586,10 @@
     },
     "dplyr": {
       "Package": "dplyr",
-      "Version": "1.0.8",
+      "Version": "1.0.9",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ef47665e64228a17609d6df877bf86f2",
+      "Hash": "f0bda1627a7f5d3f9a0b5add931596ac",
       "Requirements": [
         "R6",
         "generics",
@@ -572,10 +623,10 @@
     },
     "extrafont": {
       "Package": "extrafont",
-      "Version": "0.17",
+      "Version": "0.18",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "7f2f50e8f998a4bea4b04650fc4f2ca8",
+      "Hash": "07a8a50195fc77e8690fd8bc4e87e6a0",
       "Requirements": [
         "Rttf2pt1",
         "extrafontdb"
@@ -669,12 +720,27 @@
       "Hash": "177475892cf4a55865868527654a7741",
       "Requirements": []
     },
-    "ggplot2": {
-      "Package": "ggplot2",
-      "Version": "3.3.5",
+    "gert": {
+      "Package": "gert",
+      "Version": "1.6.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "d7566c471c7b17e095dd023b9ef155ad",
+      "Hash": "98c014c4c933f23ea5a0321a4d0b588b",
+      "Requirements": [
+        "askpass",
+        "credentials",
+        "openssl",
+        "rstudioapi",
+        "sys",
+        "zip"
+      ]
+    },
+    "ggplot2": {
+      "Package": "ggplot2",
+      "Version": "3.3.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "0fb26d0674c82705c6b701d1a61e02ea",
       "Requirements": [
         "MASS",
         "digest",
@@ -724,6 +790,28 @@
         "stringr",
         "tibble"
       ]
+    },
+    "gh": {
+      "Package": "gh",
+      "Version": "1.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "38c2580abbda249bd6afeec00d14f531",
+      "Requirements": [
+        "cli",
+        "gitcreds",
+        "httr",
+        "ini",
+        "jsonlite"
+      ]
+    },
+    "gitcreds": {
+      "Package": "gitcreds",
+      "Version": "0.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f3aefccc1cc50de6338146b62f115de8",
+      "Requirements": []
     },
     "glue": {
       "Package": "glue",
@@ -815,10 +903,10 @@
     },
     "httr": {
       "Package": "httr",
-      "Version": "1.4.2",
+      "Version": "1.4.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "a525aba14184fec243f9eaec62fbed43",
+      "Hash": "88d1b310583777edf01ccd1216fb0b2b",
       "Requirements": [
         "R6",
         "curl",
@@ -826,6 +914,14 @@
         "mime",
         "openssl"
       ]
+    },
+    "ini": {
+      "Package": "ini",
+      "Version": "0.3.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6154ec2223172bce8162d4153cda21f7",
+      "Requirements": []
     },
     "isoband": {
       "Package": "isoband",
@@ -875,10 +971,10 @@
     },
     "knitr": {
       "Package": "knitr",
-      "Version": "1.38",
+      "Version": "1.39",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "10b3dc3c6acb925910edda5d0543b3a2",
+      "Hash": "029ab7c4badd3cf8af69016b2ba27493",
       "Requirements": [
         "evaluate",
         "highr",
@@ -994,6 +1090,17 @@
       "Hash": "87da6ccdcee6077a7d5719406bf3ae45",
       "Requirements": []
     },
+    "memoise": {
+      "Package": "memoise",
+      "Version": "2.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e2817ccf4a065c5d9d7f2cfbe7c1d78c",
+      "Requirements": [
+        "cachem",
+        "rlang"
+      ]
+    },
     "meta": {
       "Package": "meta",
       "Version": "5.2-0",
@@ -1007,17 +1114,41 @@
         "xml2"
       ]
     },
-    "metafor": {
-      "Package": "metafor",
-      "Version": "3.0-2",
+    "metadat": {
+      "Package": "metadat",
+      "Version": "1.2-0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "b598da1155b3f86b380c1a32f6f3b224",
+      "Hash": "197625f3d9a294849a2759be23f76831",
+      "Requirements": [
+        "mathjaxr"
+      ]
+    },
+    "metafor": {
+      "Package": "metafor",
+      "Version": "3.4-0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "bf0ad6c3e7626139ba749f2e311fafa7",
       "Requirements": [
         "Matrix",
         "mathjaxr",
+        "metadat",
         "nlme",
         "pbapply"
+      ]
+    },
+    "metathis": {
+      "Package": "metathis",
+      "Version": "1.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "4298036cc76c4164741fdd2ab5b6f57b",
+      "Requirements": [
+        "htmltools",
+        "knitr",
+        "magrittr",
+        "purrr"
       ]
     },
     "mgcv": {
@@ -1071,10 +1202,10 @@
     },
     "nloptr": {
       "Package": "nloptr",
-      "Version": "2.0.0",
+      "Version": "2.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6e45c045fea34a9d0d1ceaa6fb7c4e91",
+      "Hash": "158916799afe8d32e07b0b1920ea79a8",
       "Requirements": [
         "testthat"
       ]
@@ -1166,6 +1297,23 @@
       "Hash": "e293e79be42ffd336d938937fd3017fb",
       "Requirements": [
         "processx"
+      ]
+    },
+    "pkgbuild": {
+      "Package": "pkgbuild",
+      "Version": "1.3.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "66d2adfed274daf81ccfe77d974c3b9b",
+      "Requirements": [
+        "R6",
+        "callr",
+        "cli",
+        "crayon",
+        "desc",
+        "prettyunits",
+        "rprojroot",
+        "withr"
       ]
     },
     "pkgconfig": {
@@ -1320,10 +1468,10 @@
     },
     "ps": {
       "Package": "ps",
-      "Version": "1.6.0",
+      "Version": "1.7.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "32620e2001c1dce1af49c49dccbb9420",
+      "Hash": "eef74b13f32cae6bb0d495e53317c44c",
       "Requirements": []
     },
     "purrr": {
@@ -1359,14 +1507,16 @@
     },
     "quantreg": {
       "Package": "quantreg",
-      "Version": "5.88",
+      "Version": "5.93",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "b7d49f60ce945abad300246d4766326a",
+      "Hash": "48485e5cbfe385caf47ce1d9442f5147",
       "Requirements": [
+        "MASS",
         "Matrix",
         "MatrixModels",
-        "SparseM"
+        "SparseM",
+        "survival"
       ]
     },
     "rappdirs": {
@@ -1376,6 +1526,27 @@
       "Repository": "CRAN",
       "Hash": "5e3c5dc0b071b21fa128676560dbe94d",
       "Requirements": []
+    },
+    "rcmdcheck": {
+      "Package": "rcmdcheck",
+      "Version": "1.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "8f25ebe2ec38b1f2aef3b0d2ef76f6c4",
+      "Requirements": [
+        "R6",
+        "callr",
+        "cli",
+        "curl",
+        "desc",
+        "digest",
+        "pkgbuild",
+        "prettyunits",
+        "rprojroot",
+        "sessioninfo",
+        "withr",
+        "xopen"
+      ]
     },
     "readr": {
       "Package": "readr",
@@ -1428,6 +1599,14 @@
         "tibble"
       ]
     },
+    "remotes": {
+      "Package": "remotes",
+      "Version": "2.4.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "227045be9aee47e6dda9bb38ac870d67",
+      "Requirements": []
+    },
     "renv": {
       "Package": "renv",
       "Version": "0.15.4",
@@ -1478,10 +1657,10 @@
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.13",
+      "Version": "2.14",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ac78f4d2e0289d4cba73b88af567b8b1",
+      "Hash": "31b60a882fabfabf6785b8599ffeb8ba",
       "Requirements": [
         "bslib",
         "evaluate",
@@ -1493,6 +1672,28 @@
         "tinytex",
         "xfun",
         "yaml"
+      ]
+    },
+    "roxygen2": {
+      "Package": "roxygen2",
+      "Version": "7.1.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "eb9849556c4250305106e82edae35b72",
+      "Requirements": [
+        "R6",
+        "brew",
+        "commonmark",
+        "cpp11",
+        "desc",
+        "digest",
+        "knitr",
+        "pkgload",
+        "purrr",
+        "rlang",
+        "stringi",
+        "stringr",
+        "xml2"
       ]
     },
     "rpart": {
@@ -1519,6 +1720,17 @@
       "Hash": "06c85365a03fdaf699966cc1d3cf53ea",
       "Requirements": []
     },
+    "rversions": {
+      "Package": "rversions",
+      "Version": "2.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f88fab00907b312f8b23ec13e2d437cb",
+      "Requirements": [
+        "curl",
+        "xml2"
+      ]
+    },
     "sass": {
       "Package": "sass",
       "Version": "0.4.1",
@@ -1535,10 +1747,10 @@
     },
     "scales": {
       "Package": "scales",
-      "Version": "1.1.1",
+      "Version": "1.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6f76f71042411426ec8df6c54f34e6dd",
+      "Hash": "6e8750cdd13477aa440d453da93d5cac",
       "Requirements": [
         "R6",
         "RColorBrewer",
@@ -1546,7 +1758,18 @@
         "labeling",
         "lifecycle",
         "munsell",
+        "rlang",
         "viridisLite"
+      ]
+    },
+    "sessioninfo": {
+      "Package": "sessioninfo",
+      "Version": "1.2.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "3f9796a8d0a0e8c6eb49a4b029359d1f",
+      "Requirements": [
+        "cli"
       ]
     },
     "shiny": {
@@ -1602,6 +1825,21 @@
         "htmltools",
         "jsonlite",
         "sass",
+        "shiny"
+      ]
+    },
+    "shinya11y": {
+      "Package": "shinya11y",
+      "Version": "0.0.0.9000",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteUsername": "ewenme",
+      "RemoteRepo": "shinya11y",
+      "RemoteRef": "master",
+      "RemoteSha": "4f17db8f0c06e7332258e6c499e3c4af36fd4a17",
+      "Hash": "09d457c4fa211ee51a6621b884a3a5b1",
+      "Requirements": [
         "shiny"
       ]
     },
@@ -1681,16 +1919,16 @@
     },
     "skimr": {
       "Package": "skimr",
-      "Version": "2.1.3",
+      "Version": "2.1.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "333780f799b3bb5040708582a035850e",
+      "Hash": "ffdd2d11832e37d92a118d44dc44f50e",
       "Requirements": [
         "cli",
-        "crayon",
         "dplyr",
         "knitr",
         "magrittr",
+        "pillar",
         "purrr",
         "repr",
         "rlang",
@@ -1698,8 +1936,7 @@
         "tibble",
         "tidyr",
         "tidyselect",
-        "vctrs",
-        "withr"
+        "vctrs"
       ]
     },
     "snakecase": {
@@ -1723,10 +1960,10 @@
     },
     "sp": {
       "Package": "sp",
-      "Version": "1.4-6",
+      "Version": "1.4-7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ce8613f4e8c84ef4da9eba65b874ebe9",
+      "Hash": "c5dad1d43440f0c426a6d29b30b333fa",
       "Requirements": [
         "lattice"
       ]
@@ -1815,10 +2052,10 @@
     },
     "testthat": {
       "Package": "testthat",
-      "Version": "3.1.3",
+      "Version": "3.1.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "affcf9db2c99dd2c7e6459ef55ed3385",
+      "Hash": "f76c2a02d0fdc24aa7a47ea34261a6e3",
       "Requirements": [
         "R6",
         "brio",
@@ -1858,10 +2095,10 @@
     },
     "tibble": {
       "Package": "tibble",
-      "Version": "3.1.6",
+      "Version": "3.1.7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8a8f02d1934dfd6431c671361510dd0b",
+      "Hash": "08415af406e3dd75049afef9552e7355",
       "Requirements": [
         "ellipsis",
         "fansi",
@@ -1927,6 +2164,34 @@
         "cpp11"
       ]
     },
+    "usethis": {
+      "Package": "usethis",
+      "Version": "2.1.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "c499f488e6dd7718accffaee5bc5a79b",
+      "Requirements": [
+        "cli",
+        "clipr",
+        "crayon",
+        "curl",
+        "desc",
+        "fs",
+        "gert",
+        "gh",
+        "glue",
+        "jsonlite",
+        "lifecycle",
+        "purrr",
+        "rappdirs",
+        "rlang",
+        "rprojroot",
+        "rstudioapi",
+        "whisker",
+        "withr",
+        "yaml"
+      ]
+    },
     "utf8": {
       "Package": "utf8",
       "Version": "1.2.2",
@@ -1937,10 +2202,10 @@
     },
     "vctrs": {
       "Package": "vctrs",
-      "Version": "0.4.0",
+      "Version": "0.4.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "95c2573b232eac82df562f9e300f9790",
+      "Hash": "8b54f22e2a58c4f275479c92ce041a57",
       "Requirements": [
         "cli",
         "glue",
@@ -2024,6 +2289,14 @@
         "withr"
       ]
     },
+    "whisker": {
+      "Package": "whisker",
+      "Version": "0.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "ca970b96d894e90397ed20637a0c1bbe",
+      "Requirements": []
+    },
     "withr": {
       "Package": "withr",
       "Version": "2.5.0",
@@ -2047,6 +2320,16 @@
       "Repository": "CRAN",
       "Hash": "40682ed6a969ea5abfd351eb67833adc",
       "Requirements": []
+    },
+    "xopen": {
+      "Package": "xopen",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "6c85f015dee9cc7710ddd20f86881f58",
+      "Requirements": [
+        "processx"
+      ]
     },
     "xtable": {
       "Package": "xtable",
@@ -2084,10 +2367,10 @@
     },
     "zoo": {
       "Package": "zoo",
-      "Version": "1.8-9",
+      "Version": "1.8-10",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "035d1c7c12593038c26fb1c2fd40c4d2",
+      "Hash": "277b8b4c5b7b47e664aebfe024a2092e",
       "Requirements": [
         "lattice"
       ]

--- a/server.R
+++ b/server.R
@@ -657,7 +657,6 @@ server <- function(input, output, session) {
         tagList(
           helpText("Choose an industry sub-sector and qualification level to view further detail on subject and qualification data."),
           br(),
-          br(),
           selectizeInput("inSelect2",
             options = list(create = TRUE),
             label = "Choose an industry sub-sector:",

--- a/server.R
+++ b/server.R
@@ -637,16 +637,11 @@ server <- function(input, output, session) {
 
   observe({
     if (input$subsectorlevel=='Subject and qualification'){
+      # Render the specific ui elements for the sidebar when the Subject and 
+      # Qualification tab is selected.
       output$SubjQualInputPanel <- renderUI({
         tagList(
           helpText("Choose an industry sub-sector and qualification level to view further detail on subject and qualification data."),
-          br(),
-          actionButton("reset", "Reset",
-                       style = "color: #0b0c0c;
-                                             font-size: 12px;
-                                             font-weight: bold;
-                                             background-color: #ffffff"
-          ),
           br(),
           br(),
           selectizeInput("inSelect2",
@@ -664,11 +659,8 @@ server <- function(input, output, session) {
                          multiple = F,
                          selected = "All levels"
           ),
-              downloadButton(
-            outputId = "download_btn1",
-            label = "Download",
-            icon = shiny::icon("download")
-          ))
+          br()
+)
     }
     )
       observe({
@@ -732,46 +724,50 @@ server <- function(input, output, session) {
                           selected = "All sub-sectors"
         )
       })
+      output$hqSubTable <- renderDataTable({
+        validate(need(!is.null(input$inSelect),"Table will go here."))
+        data <- stat_hq_sub %>%
+          filter(Region == input$region,
+                 Sector == input$sector,
+                 Level_order == input$inSelect,
+                 Subsector == input$inSelect2) %>%
+          select(Qualification,
+                 Level = Level_order_UI,
+                 Percentage = perc,
+                 "Average earnings" = median_income)
+        DT::datatable(data,
+                      rownames = FALSE,
+                      options = list(
+                        searching = FALSE,
+                        pageLength = 10,
+                        lengthMenu = c(10, 20),
+                        searchHighlight = TRUE,
+                        dom = "p",
+                        scrollX = TRUE
+                      ),
+                      width = "625px",
+                      height = "350px",
+                      style = "bootstrap", class = "table-bordered table-condensed align-center"
+        ) %>%
+          formatPercentage(3, digits = 1) %>%
+          formatCurrency(4, digits = 0, currency = "£", mark = ",") %>%
+          formatStyle(0,
+                      target = "row",
+                      color = "black",
+                      fontSize = "14px",
+                      backgroundColor = "white",
+                      lineHeight = "100%"
+          )
+      })
       
       
+    } else {
+      output$SubjQualInputPanel <- renderUI({
+        tagList(br())
+      })
     }
   })
   
-  output$hqSubTable <- renderDataTable({
-    validate(need(!is.null(input$inSelect),"Table will go here."))
-    data <- stat_hq_sub %>%
-      filter(Region == input$region,
-             Sector == input$sector,
-             Level_order == input$inSelect,
-             Subsector == input$inSelect2) %>%
-      select(Qualification,
-             Level = Level_order_UI,
-             Percentage = perc,
-             "Average earnings" = median_income)
-    DT::datatable(data,
-                  rownames = FALSE,
-                  options = list(
-                    searching = FALSE,
-                    pageLength = 10,
-                    lengthMenu = c(10, 20),
-                    searchHighlight = TRUE,
-                    dom = "p",
-                    scrollX = TRUE
-                  ),
-                  width = "625px",
-                  height = "350px",
-                  style = "bootstrap", class = "table-bordered table-condensed align-center"
-    ) %>%
-      formatPercentage(3, digits = 1) %>%
-      formatCurrency(4, digits = 0, currency = "£", mark = ",") %>%
-      formatStyle(0,
-                  target = "row",
-                  color = "black",
-                  fontSize = "14px",
-                  backgroundColor = "white",
-                  lineHeight = "100%"
-      )
-  })
   
   # KPIs selection
   selection_kpis <- reactive({

--- a/server.R
+++ b/server.R
@@ -280,25 +280,25 @@ server <- function(input, output, session) {
   indSubChart <- reactive({
     stat_subs_sub %>%
       filter(Region == input$region &
-               Sector == input$sector &
-               Subsector == input$inSelect2 &
-               Level_order == input$inSelect) %>%
+        Sector == input$sector &
+        Subsector == input$inSelect2 &
+        Level_order == input$inSelect) %>%
       ggplot(aes(
         x = reorder(Subject, -perc), y = perc,
         text = paste(
           paste0("Percentage: ", formatC(perc * 100,
-                                         digits = 1,
-                                         format = "f"
+            digits = 1,
+            format = "f"
           ), "%"),
           paste0("Volume: ", formatC(number_students_sub,
-                                     digits = 0,
-                                     format = "f",
-                                     big.mark = ","
+            digits = 0,
+            format = "f",
+            big.mark = ","
           )),
           paste0("Average Earnings: ", "£", formatC(median_income,
-                                                    digits = 0,
-                                                    format = "f",
-                                                    big.mark = ","
+            digits = 0,
+            format = "f",
+            big.mark = ","
           )),
           sep = "\n"
         )
@@ -322,7 +322,7 @@ server <- function(input, output, session) {
         panel.grid.minor.y = element_blank()
       )
   })
-  
+
 
   # Page2: Reactive stack chart InWork % --------------------------------------
 
@@ -635,9 +635,23 @@ server <- function(input, output, session) {
     }
   })
 
+  observeEvent(input$reset, {
+    updateSelectInput(session,
+      "sector",
+      choices = sectors_v,
+      selected = "Construction"
+    )
+
+    updateSelectInput(session,
+      "region",
+      choices = regions_v,
+      selected = "England"
+    )
+  })
+
   observe({
-    if (input$subsectorlevel=='Subject and qualification'){
-      # Render the specific ui elements for the sidebar when the Subject and 
+    if (input$subsectorlevel == "Subject and qualification") {
+      # Render the specific ui elements for the sidebar when the Subject and
       # Qualification tab is selected.
       output$SubjQualInputPanel <- renderUI({
         tagList(
@@ -645,130 +659,118 @@ server <- function(input, output, session) {
           br(),
           br(),
           selectizeInput("inSelect2",
-                         options = list(create = TRUE),
-                         label = "Choose an industry sub-sector:",
-                         choices = subsector_v,
-                         multiple = F,
-                         width = "100%",
-                         selected = "All sub-sectors"
+            options = list(create = TRUE),
+            label = "Choose an industry sub-sector:",
+            choices = subsector_v,
+            multiple = F,
+            width = "100%",
+            selected = "All sub-sectors"
           ),
           selectizeInput("inSelect",
-                         options = list(create = TRUE),
-                         label = "Choose a qualification level:",
-                         choices = levelsRelabelled,
-                         multiple = F,
-                         selected = "All levels"
+            options = list(create = TRUE),
+            label = "Choose a qualification level:",
+            choices = levelsRelabelled,
+            multiple = F,
+            selected = "All levels"
           ),
           br()
-)
-    }
-    )
-      observe({
-        updateSelectInput(session,
-                          "inSelect2",
-                          choices = subsector_v,
-                          selected = "All sub-sectors"
-        )
-        updateSelectInput(session,
-                          "inSelect",
-                          choices = levelsRelabelled,
-                          selected = "All levels"
         )
       })
-      
+      observe({
+        updateSelectInput(session,
+          "inSelect2",
+          choices = subsector_v,
+          selected = "All sub-sectors"
+        )
+        updateSelectInput(session,
+          "inSelect",
+          choices = levelsRelabelled,
+          selected = "All levels"
+        )
+      })
+
       output$indSubChart <- renderPlotly({
         validate(
           need(nrow(stat_subs_sub %>%
-                      filter(Region == input$region &
-                               Sector == input$sector &
-                               Subsector == input$inSelect2 &
-                               Level_order == input$inSelect)) > 0, "There are no employees matching this selection. Please select again.")
+            filter(Region == input$region &
+              Sector == input$sector &
+              Subsector == input$inSelect2 &
+              Level_order == input$inSelect)) > 0, "There are no employees matching this selection. Please select again.")
         )
         ggplotly(indSubChart(), tooltip = "text")
       })
-      
+
       observe({
         updateSelectInput(session,
-                          "inSelect",
-                          choices = hq_sub_v(),
-                          selected = "All levels"
+          "inSelect",
+          choices = hq_sub_v(),
+          selected = "All levels"
         )
         updateSelectInput(session,
-                          "inSelect2",
-                          choices = sect_sub_v(),
-                          selected = "All sub-sectors"
+          "inSelect2",
+          choices = sect_sub_v(),
+          selected = "All sub-sectors"
         )
       })
+      # Reset Levels and sub-sectors inputs when reset button pressed.
       observeEvent(input$reset, {
         updateSelectInput(session,
-                          "sector",
-                          choices = sectors_v,
-                          selected = "Construction"
+          "inSelect",
+          choices = hq_sub_v(),
+          selected = "All levels"
         )
-        
         updateSelectInput(session,
-                          "region",
-                          choices = regions_v,
-                          selected = "England"
-        )
-        
-        updateSelectInput(session,
-                          "inSelect",
-                          choices = hq_sub_v(),
-                          selected = "All levels"
-        )
-        
-        updateSelectInput(session,
-                          "inSelect2",
-                          choices = sect_sub_v(),
-                          selected = "All sub-sectors"
+          "inSelect2",
+          choices = sect_sub_v(),
+          selected = "All sub-sectors"
         )
       })
       output$hqSubTable <- renderDataTable({
-        validate(need(!is.null(input$inSelect),"Table will go here."))
+        validate(need(!is.null(input$inSelect), "Table will go here."))
         data <- stat_hq_sub %>%
-          filter(Region == input$region,
-                 Sector == input$sector,
-                 Level_order == input$inSelect,
-                 Subsector == input$inSelect2) %>%
+          filter(
+            Region == input$region,
+            Sector == input$sector,
+            Level_order == input$inSelect,
+            Subsector == input$inSelect2
+          ) %>%
           select(Qualification,
-                 Level = Level_order_UI,
-                 Percentage = perc,
-                 "Average earnings" = median_income)
+            Level = Level_order_UI,
+            Percentage = perc,
+            "Average earnings" = median_income
+          )
         DT::datatable(data,
-                      rownames = FALSE,
-                      options = list(
-                        searching = FALSE,
-                        pageLength = 10,
-                        lengthMenu = c(10, 20),
-                        searchHighlight = TRUE,
-                        dom = "p",
-                        scrollX = TRUE
-                      ),
-                      width = "625px",
-                      height = "350px",
-                      style = "bootstrap", class = "table-bordered table-condensed align-center"
+          rownames = FALSE,
+          options = list(
+            searching = FALSE,
+            pageLength = 10,
+            lengthMenu = c(10, 20),
+            searchHighlight = TRUE,
+            dom = "p",
+            scrollX = TRUE
+          ),
+          width = "625px",
+          height = "350px",
+          style = "bootstrap", class = "table-bordered table-condensed align-center"
         ) %>%
           formatPercentage(3, digits = 1) %>%
           formatCurrency(4, digits = 0, currency = "£", mark = ",") %>%
           formatStyle(0,
-                      target = "row",
-                      color = "black",
-                      fontSize = "14px",
-                      backgroundColor = "white",
-                      lineHeight = "100%"
+            target = "row",
+            color = "black",
+            fontSize = "14px",
+            backgroundColor = "white",
+            lineHeight = "100%"
           )
       })
-      
-      
     } else {
       output$SubjQualInputPanel <- renderUI({
         tagList(br())
       })
     }
   })
-  
-  
+
+
   # KPIs selection
   selection_kpis <- reactive({
     kpis %>%
@@ -907,7 +909,7 @@ server <- function(input, output, session) {
     )
     ggplotly(inWorkChart(), tooltip = "text")
   })
-  
+
 
   # page 2: treeplot
   output$box4title <- renderText({
@@ -943,9 +945,9 @@ server <- function(input, output, session) {
     HTML(svg_html_legend)
   })
 
-  
-  
-  
+
+
+
   # Download data -----------------------------------------------------------
 
   to_download_pg1 <- reactiveValues(

--- a/ui.R
+++ b/ui.R
@@ -149,51 +149,7 @@ fluidPage(
             inline = F,
             width = "50%"
           ),
-          conditionalPanel(
-            condition = "input.subsectorlevel=='Subject and qualification'",
-
-            ### Help text ---------------------------------------------------------------------
-            helpText("Choose an industry sub-sector and qualification level to view further detail on subject and qualification data."),
-            br(),
-
-            ### Reset button -------------------------------------------------------------------
-
-            actionButton("reset", "Reset",
-              style = "color: #0b0c0c;
-                                       font-size: 12px;
-                                       font-weight: bold;
-                                       background-color: #ffffff"
-            ),
-            br(), br(),
-
-            ### Sub-Sector input -------------------------------------------------------------------
-            selectizeInput("inSelect2",
-              options = list(create = TRUE),
-              label = "Choose an industry sub-sector:",
-              choices = subsector_v,
-              multiple = F,
-              width = "100%",
-              selected = "All sub-sectors"
-            ),
-
-
-            ### Level input -------------------------------------------------------------------
-            selectizeInput("inSelect",
-              options = list(create = TRUE),
-              label = "Choose a qualification level:",
-              choices = levelsRelabelled,
-              multiple = F,
-              selected = "All levels"
-            ),
-
-            ### Download button -------------------------------------------------------------------
-
-            downloadButton(
-              outputId = "download_btn1",
-              label = "Download",
-              icon = shiny::icon("download")
-            )
-          )
+          uiOutput("SubjQualInputPanel"),
         ), # end of sidebar
 
         ## Main panel 1============================================================================

--- a/ui.R
+++ b/ui.R
@@ -152,7 +152,7 @@ fluidPage(
           uiOutput("SubjQualInputPanel"),
           br(),
           actionButton("reset", "Reset",
-                       style = "color: #0b0c0c;
+            style = "color: #0b0c0c;
                                              font-size: 12px;
                                              font-weight: bold;
                                              background-color: #ffffff"

--- a/ui.R
+++ b/ui.R
@@ -150,6 +150,22 @@ fluidPage(
             width = "50%"
           ),
           uiOutput("SubjQualInputPanel"),
+          br(),
+          actionButton("reset", "Reset",
+                       style = "color: #0b0c0c;
+                                             font-size: 12px;
+                                             font-weight: bold;
+                                             background-color: #ffffff"
+          ),
+          br(),
+          br(),
+          downloadButton(
+            outputId = "download_btn1",
+            label = "Download",
+            icon = shiny::icon("download")
+          ),
+          br(),
+          br()
         ), # end of sidebar
 
         ## Main panel 1============================================================================


### PR DESCRIPTION
I was concerned that the conditionalPanel() function appears to cause some errors in the browser console (when running in Edge at least) and that we had some issues with conditionalPanel() on the LEO graduate dashboard (see #24).

I've recoded the conditionalPanel() bit of the UI into a renderUI() call embedded on an observe(), with an if() statement checking which tab is selected. Behaviour seen by the user is pretty much the same, but no underlying use of the conditionalPanel function.

Whilst I was making the edits, it seemed odd that the reset and download buttons are only on the second tab and not the first, so I've pulled those outside the if() statement and they now get rendered regardless of which tab is selected (TBC - @liviahull  & @Jkhamis). Here's some screenshots of what it looks like now for the two different tabs:

**Sub-sector and level**
![ConditionalInputs_subsectorlevel](https://user-images.githubusercontent.com/230859/169314771-cdded8c8-9951-431c-9b8c-fb4773d4e7da.JPG)

**Subject and qualification**
![ConditionalInputs_subjectqual](https://user-images.githubusercontent.com/230859/169314810-73f0a8cd-c028-4f3c-b3e1-9308fa5cb42b.JPG)

