### PR TITLE
Try real data 23 05

### DIFF
--- a/R/dashboard_text.R
+++ b/R/dashboard_text.R
@@ -37,7 +37,8 @@ welcome_text <- function() {
 
 industry_overview_text <- function() {
   div(
-    "This tab provides a region-specific overview of employees who work in each industry sector. It includes information on overall levels of education and average earnings, the sub-sectors of work, and subject and qualification choices. It also includes a forecast of annual employment growth in the sector between 2022 and 2027. ",
+    "This tab provides a region-specific overview of employees who work in each industry sector. It includes information on overall levels of education and average earnings, the sub-sectors of work, and subject and qualification choices. 
+    It also includes a forecast of annual employment growth in the sector between 2022 and 2027. In this dashboard, region is based on the home postcode of the employee.",
     br(), br(),
     "Data included on the page are for employees who turn age 25-30 in the 2018-19 tax year.
     Specifically, the dashboard covers employees born between September 1988 and August 1993

--- a/R/dashboard_text.R
+++ b/R/dashboard_text.R
@@ -82,9 +82,9 @@ for these qualifications have been mapped to SSA tier 1. The titles for these qu
 qualification type and the JACs principal subject code.",
     br(), br(),
     tags$h4("Median annual earnings"),
-    "The median earnings in this dashboard are presented as raw figures. 
+    "The median earnings in this dashboard are presented as raw figures.
     They do not seek to control for differences in employee characteristics that may influence earnings over time or across different employee populations.",
-    "Earnings estimates are based on information recorded through the PAYE system. The earnings estimates do not include any income that was recorded though the self-assessment tax system. This means that earnings will be underreported for employees who have self-assessment income in addition to earnings from paid employment collected by the PAYE system. 
+    "Earnings estimates are based on information recorded through the PAYE system. The earnings estimates do not include any income that was recorded though the self-assessment tax system. This means that earnings will be underreported for employees who have self-assessment income in addition to earnings from paid employment collected by the PAYE system.
     The PAYE records from HMRC do not include reliable information on the hours worked in employment so it is not possible to accurately distinguish between employees in full time and part time employment.", br(), br(),
     tags$h4("Rounding and suppression"),
     "Employee numbers are rounded to the nearest 10, annual median earnings are rounded to

--- a/R/dashboard_text.R
+++ b/R/dashboard_text.R
@@ -37,7 +37,7 @@ welcome_text <- function() {
 
 industry_overview_text <- function() {
   div(
-    "This tab provides a region-specific overview of employees who work in each industry sector. It includes information on overall levels of education and average earnings, the sub-sectors of work, and subject and qualification choices. 
+    "This tab provides a region-specific overview of employees who work in each industry sector. It includes information on overall levels of education and average earnings, the sub-sectors of work, and subject and qualification choices.
     It also includes a forecast of annual employment growth in the sector between 2022 and 2027. In this dashboard, region is based on the home postcode of the employee.",
     br(), br(),
     "Data included on the page are for employees who turn age 25-30 in the 2018-19 tax year.

--- a/R/dashboard_text.R
+++ b/R/dashboard_text.R
@@ -10,7 +10,7 @@ welcome_text <- function() {
     br(),
     "The data in the career pathways dashboard aims to use this development to:",
     tags$ul(
-      tags$li("Explore how LEO can help us to understand the education pathways of employees in different industry sectors;"),
+      tags$li("Explore how LEO can help us to understand the education pathways of employees in different industry sectors."),
       tags$li("Demonstrate how LEO data could be used to develop a careers information tool via an interactive dashboard.")
     ),
     "This dashboard has been produced to support the aims of the ",
@@ -67,7 +67,7 @@ industry_overview_text <- function() {
     "Please note that these projections are based on employment estimates derived from published labour market data.
     They are not precise predictions of future employment levels, but represent the most likely trajectory of labour market change, given long-term trends in the economy and explicit assumptions about likely future economic change.
     The projections were created when it was expected there would be a negotiated Brexit and before the Covid-19 pandemic, which may result in considerable disruption to the UK and world economic system.
-    These projections indicate what the labour market might have looked like before the pandemic. They, therefore, can be used to provide a measure of how the labour market has changed and the implications of the pandemic.",
+    These projections indicate what the labour market might have looked like before the pandemic. They, therefore, cannot be used to provide a measure of how the labour market has changed and the implications of the pandemic.",
     br(), br(),
     tags$h4("Education level, subject, and qualification"),
     "Education level and subject are based on highest qualification achievement at the start of the 2018-19 tax year.
@@ -82,13 +82,10 @@ for these qualifications have been mapped to SSA tier 1. The titles for these qu
 qualification type and the JACs principal subject code.",
     br(), br(),
     tags$h4("Median annual earnings"),
-    "Earnings estimates are based on information recorded through the PAYE system.",
-    "The PAYE records from HMRC do not include reliable information on the hours
-    worked in employment so it is not possible to accurately distinguish between
-    employees in full time and part time employment. The median earnings in this
-    dashboard are presented as raw figures. They do not seek to control for
-    differences in employee characteristics that may influence earnings over
-    time or across different employee populations.", br(), br(),
+    "The median earnings in this dashboard are presented as raw figures. 
+    They do not seek to control for differences in employee characteristics that may influence earnings over time or across different employee populations.",
+    "Earnings estimates are based on information recorded through the PAYE system. The earnings estimates do not include any income that was recorded though the self-assessment tax system. This means that earnings will be underreported for employees who have self-assessment income in addition to earnings from paid employment collected by the PAYE system. 
+    The PAYE records from HMRC do not include reliable information on the hours worked in employment so it is not possible to accurately distinguish between employees in full time and part time employment.", br(), br(),
     tags$h4("Rounding and suppression"),
     "Employee numbers are rounded to the nearest 10, annual median earnings are rounded to
     the nearest 100 and percentages are provided to the nearest one decimal place.

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -51,16 +51,6 @@ levels_v <- stat_hq_sub %>%
   distinct(Level_order, .keep_all = F) %>%
   unlist(use.names = F)
 
-# vector for relabel level of qualification
-
-levelsRelabelled <- c(
-  "Below level 2 (GCSE grades 1-3)",
-  "Level 2 (GCSE grades 4-9)",
-  "Level 3 (GCE A level)",
-  "Level 4/5 (HNC or HND)",
-  "Level 6 (Degree)",
-  "Level 7 (Master's degree)"
-)
 
 # second page -------------------------------------------------------------
 

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.1.3",
+    "Version": "4.1.2",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -59,10 +59,10 @@
     },
     "MASS": {
       "Package": "MASS",
-      "Version": "7.3-57",
+      "Version": "7.3-56",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "71476c1d88d1ebdf31580e5a257d5d31",
+      "Hash": "af0e1955cb80bb36b7988cc657db261e",
       "Requirements": []
     },
     "Matrix": {
@@ -311,14 +311,6 @@
       "Hash": "0baa960e3b49c6176a4f42addcbacc59",
       "Requirements": []
     },
-    "brew": {
-      "Package": "brew",
-      "Version": "1.0-7",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "38875ea52350ff4b4c03849fc69736c8",
-      "Requirements": []
-    },
     "brio": {
       "Package": "brio",
       "Version": "1.1.3",
@@ -386,10 +378,10 @@
     },
     "cli": {
       "Package": "cli",
-      "Version": "3.3.0",
+      "Version": "3.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "23abf173c2b783dcc43379ab9bba00ee",
+      "Hash": "1bdb126893e9ce6aae50ad1d6fc32faf",
       "Requirements": [
         "glue"
       ]
@@ -461,20 +453,6 @@
       "Hash": "8dc45fd8a1ee067a92b85ef274e66d6a",
       "Requirements": []
     },
-    "credentials": {
-      "Package": "credentials",
-      "Version": "1.3.2",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "93762d0a34d78e6a025efdbfb5c6bb41",
-      "Requirements": [
-        "askpass",
-        "curl",
-        "jsonlite",
-        "openssl",
-        "sys"
-      ]
-    },
     "crosstalk": {
       "Package": "crosstalk",
       "Version": "1.2.0",
@@ -537,35 +515,6 @@
         "rprojroot"
       ]
     },
-    "devtools": {
-      "Package": "devtools",
-      "Version": "2.4.3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "fc35e13bb582e5fe6f63f3d647a4cbe5",
-      "Requirements": [
-        "callr",
-        "cli",
-        "desc",
-        "ellipsis",
-        "fs",
-        "httr",
-        "lifecycle",
-        "memoise",
-        "pkgbuild",
-        "pkgload",
-        "rcmdcheck",
-        "remotes",
-        "rlang",
-        "roxygen2",
-        "rstudioapi",
-        "rversions",
-        "sessioninfo",
-        "testthat",
-        "usethis",
-        "withr"
-      ]
-    },
     "diffobj": {
       "Package": "diffobj",
       "Version": "0.3.5",
@@ -586,10 +535,10 @@
     },
     "dplyr": {
       "Package": "dplyr",
-      "Version": "1.0.9",
+      "Version": "1.0.8",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "f0bda1627a7f5d3f9a0b5add931596ac",
+      "Hash": "ef47665e64228a17609d6df877bf86f2",
       "Requirements": [
         "R6",
         "generics",
@@ -623,10 +572,10 @@
     },
     "extrafont": {
       "Package": "extrafont",
-      "Version": "0.18",
+      "Version": "0.17",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "07a8a50195fc77e8690fd8bc4e87e6a0",
+      "Hash": "7f2f50e8f998a4bea4b04650fc4f2ca8",
       "Requirements": [
         "Rttf2pt1",
         "extrafontdb"
@@ -720,27 +669,12 @@
       "Hash": "177475892cf4a55865868527654a7741",
       "Requirements": []
     },
-    "gert": {
-      "Package": "gert",
-      "Version": "1.6.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "98c014c4c933f23ea5a0321a4d0b588b",
-      "Requirements": [
-        "askpass",
-        "credentials",
-        "openssl",
-        "rstudioapi",
-        "sys",
-        "zip"
-      ]
-    },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "3.3.6",
+      "Version": "3.3.5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "0fb26d0674c82705c6b701d1a61e02ea",
+      "Hash": "d7566c471c7b17e095dd023b9ef155ad",
       "Requirements": [
         "MASS",
         "digest",
@@ -790,28 +724,6 @@
         "stringr",
         "tibble"
       ]
-    },
-    "gh": {
-      "Package": "gh",
-      "Version": "1.3.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "38c2580abbda249bd6afeec00d14f531",
-      "Requirements": [
-        "cli",
-        "gitcreds",
-        "httr",
-        "ini",
-        "jsonlite"
-      ]
-    },
-    "gitcreds": {
-      "Package": "gitcreds",
-      "Version": "0.1.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "f3aefccc1cc50de6338146b62f115de8",
-      "Requirements": []
     },
     "glue": {
       "Package": "glue",
@@ -903,10 +815,10 @@
     },
     "httr": {
       "Package": "httr",
-      "Version": "1.4.3",
+      "Version": "1.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "88d1b310583777edf01ccd1216fb0b2b",
+      "Hash": "a525aba14184fec243f9eaec62fbed43",
       "Requirements": [
         "R6",
         "curl",
@@ -914,14 +826,6 @@
         "mime",
         "openssl"
       ]
-    },
-    "ini": {
-      "Package": "ini",
-      "Version": "0.3.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "6154ec2223172bce8162d4153cda21f7",
-      "Requirements": []
     },
     "isoband": {
       "Package": "isoband",
@@ -971,10 +875,10 @@
     },
     "knitr": {
       "Package": "knitr",
-      "Version": "1.39",
+      "Version": "1.38",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "029ab7c4badd3cf8af69016b2ba27493",
+      "Hash": "10b3dc3c6acb925910edda5d0543b3a2",
       "Requirements": [
         "evaluate",
         "highr",
@@ -1090,17 +994,6 @@
       "Hash": "87da6ccdcee6077a7d5719406bf3ae45",
       "Requirements": []
     },
-    "memoise": {
-      "Package": "memoise",
-      "Version": "2.0.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "e2817ccf4a065c5d9d7f2cfbe7c1d78c",
-      "Requirements": [
-        "cachem",
-        "rlang"
-      ]
-    },
     "meta": {
       "Package": "meta",
       "Version": "5.2-0",
@@ -1114,41 +1007,17 @@
         "xml2"
       ]
     },
-    "metadat": {
-      "Package": "metadat",
-      "Version": "1.2-0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "197625f3d9a294849a2759be23f76831",
-      "Requirements": [
-        "mathjaxr"
-      ]
-    },
     "metafor": {
       "Package": "metafor",
-      "Version": "3.4-0",
+      "Version": "3.0-2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "bf0ad6c3e7626139ba749f2e311fafa7",
+      "Hash": "b598da1155b3f86b380c1a32f6f3b224",
       "Requirements": [
         "Matrix",
         "mathjaxr",
-        "metadat",
         "nlme",
         "pbapply"
-      ]
-    },
-    "metathis": {
-      "Package": "metathis",
-      "Version": "1.1.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "4298036cc76c4164741fdd2ab5b6f57b",
-      "Requirements": [
-        "htmltools",
-        "knitr",
-        "magrittr",
-        "purrr"
       ]
     },
     "mgcv": {
@@ -1202,10 +1071,10 @@
     },
     "nloptr": {
       "Package": "nloptr",
-      "Version": "2.0.1",
+      "Version": "2.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "158916799afe8d32e07b0b1920ea79a8",
+      "Hash": "6e45c045fea34a9d0d1ceaa6fb7c4e91",
       "Requirements": [
         "testthat"
       ]
@@ -1297,23 +1166,6 @@
       "Hash": "e293e79be42ffd336d938937fd3017fb",
       "Requirements": [
         "processx"
-      ]
-    },
-    "pkgbuild": {
-      "Package": "pkgbuild",
-      "Version": "1.3.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "66d2adfed274daf81ccfe77d974c3b9b",
-      "Requirements": [
-        "R6",
-        "callr",
-        "cli",
-        "crayon",
-        "desc",
-        "prettyunits",
-        "rprojroot",
-        "withr"
       ]
     },
     "pkgconfig": {
@@ -1468,10 +1320,10 @@
     },
     "ps": {
       "Package": "ps",
-      "Version": "1.7.0",
+      "Version": "1.6.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "eef74b13f32cae6bb0d495e53317c44c",
+      "Hash": "32620e2001c1dce1af49c49dccbb9420",
       "Requirements": []
     },
     "purrr": {
@@ -1507,16 +1359,14 @@
     },
     "quantreg": {
       "Package": "quantreg",
-      "Version": "5.93",
+      "Version": "5.88",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "48485e5cbfe385caf47ce1d9442f5147",
+      "Hash": "b7d49f60ce945abad300246d4766326a",
       "Requirements": [
-        "MASS",
         "Matrix",
         "MatrixModels",
-        "SparseM",
-        "survival"
+        "SparseM"
       ]
     },
     "rappdirs": {
@@ -1526,27 +1376,6 @@
       "Repository": "CRAN",
       "Hash": "5e3c5dc0b071b21fa128676560dbe94d",
       "Requirements": []
-    },
-    "rcmdcheck": {
-      "Package": "rcmdcheck",
-      "Version": "1.4.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "8f25ebe2ec38b1f2aef3b0d2ef76f6c4",
-      "Requirements": [
-        "R6",
-        "callr",
-        "cli",
-        "curl",
-        "desc",
-        "digest",
-        "pkgbuild",
-        "prettyunits",
-        "rprojroot",
-        "sessioninfo",
-        "withr",
-        "xopen"
-      ]
     },
     "readr": {
       "Package": "readr",
@@ -1599,14 +1428,6 @@
         "tibble"
       ]
     },
-    "remotes": {
-      "Package": "remotes",
-      "Version": "2.4.2",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "227045be9aee47e6dda9bb38ac870d67",
-      "Requirements": []
-    },
     "renv": {
       "Package": "renv",
       "Version": "0.15.4",
@@ -1657,10 +1478,10 @@
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.14",
+      "Version": "2.13",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "31b60a882fabfabf6785b8599ffeb8ba",
+      "Hash": "ac78f4d2e0289d4cba73b88af567b8b1",
       "Requirements": [
         "bslib",
         "evaluate",
@@ -1672,28 +1493,6 @@
         "tinytex",
         "xfun",
         "yaml"
-      ]
-    },
-    "roxygen2": {
-      "Package": "roxygen2",
-      "Version": "7.1.2",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "eb9849556c4250305106e82edae35b72",
-      "Requirements": [
-        "R6",
-        "brew",
-        "commonmark",
-        "cpp11",
-        "desc",
-        "digest",
-        "knitr",
-        "pkgload",
-        "purrr",
-        "rlang",
-        "stringi",
-        "stringr",
-        "xml2"
       ]
     },
     "rpart": {
@@ -1720,17 +1519,6 @@
       "Hash": "06c85365a03fdaf699966cc1d3cf53ea",
       "Requirements": []
     },
-    "rversions": {
-      "Package": "rversions",
-      "Version": "2.1.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "f88fab00907b312f8b23ec13e2d437cb",
-      "Requirements": [
-        "curl",
-        "xml2"
-      ]
-    },
     "sass": {
       "Package": "sass",
       "Version": "0.4.1",
@@ -1747,10 +1535,10 @@
     },
     "scales": {
       "Package": "scales",
-      "Version": "1.2.0",
+      "Version": "1.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6e8750cdd13477aa440d453da93d5cac",
+      "Hash": "6f76f71042411426ec8df6c54f34e6dd",
       "Requirements": [
         "R6",
         "RColorBrewer",
@@ -1758,18 +1546,7 @@
         "labeling",
         "lifecycle",
         "munsell",
-        "rlang",
         "viridisLite"
-      ]
-    },
-    "sessioninfo": {
-      "Package": "sessioninfo",
-      "Version": "1.2.2",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "3f9796a8d0a0e8c6eb49a4b029359d1f",
-      "Requirements": [
-        "cli"
       ]
     },
     "shiny": {
@@ -1825,21 +1602,6 @@
         "htmltools",
         "jsonlite",
         "sass",
-        "shiny"
-      ]
-    },
-    "shinya11y": {
-      "Package": "shinya11y",
-      "Version": "0.0.0.9000",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteUsername": "ewenme",
-      "RemoteRepo": "shinya11y",
-      "RemoteRef": "master",
-      "RemoteSha": "4f17db8f0c06e7332258e6c499e3c4af36fd4a17",
-      "Hash": "09d457c4fa211ee51a6621b884a3a5b1",
-      "Requirements": [
         "shiny"
       ]
     },
@@ -1919,16 +1681,16 @@
     },
     "skimr": {
       "Package": "skimr",
-      "Version": "2.1.4",
+      "Version": "2.1.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ffdd2d11832e37d92a118d44dc44f50e",
+      "Hash": "333780f799b3bb5040708582a035850e",
       "Requirements": [
         "cli",
+        "crayon",
         "dplyr",
         "knitr",
         "magrittr",
-        "pillar",
         "purrr",
         "repr",
         "rlang",
@@ -1936,7 +1698,8 @@
         "tibble",
         "tidyr",
         "tidyselect",
-        "vctrs"
+        "vctrs",
+        "withr"
       ]
     },
     "snakecase": {
@@ -1960,10 +1723,10 @@
     },
     "sp": {
       "Package": "sp",
-      "Version": "1.4-7",
+      "Version": "1.4-6",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "c5dad1d43440f0c426a6d29b30b333fa",
+      "Hash": "ce8613f4e8c84ef4da9eba65b874ebe9",
       "Requirements": [
         "lattice"
       ]
@@ -2052,10 +1815,10 @@
     },
     "testthat": {
       "Package": "testthat",
-      "Version": "3.1.4",
+      "Version": "3.1.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "f76c2a02d0fdc24aa7a47ea34261a6e3",
+      "Hash": "affcf9db2c99dd2c7e6459ef55ed3385",
       "Requirements": [
         "R6",
         "brio",
@@ -2095,10 +1858,10 @@
     },
     "tibble": {
       "Package": "tibble",
-      "Version": "3.1.7",
+      "Version": "3.1.6",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "08415af406e3dd75049afef9552e7355",
+      "Hash": "8a8f02d1934dfd6431c671361510dd0b",
       "Requirements": [
         "ellipsis",
         "fansi",
@@ -2164,34 +1927,6 @@
         "cpp11"
       ]
     },
-    "usethis": {
-      "Package": "usethis",
-      "Version": "2.1.5",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "c499f488e6dd7718accffaee5bc5a79b",
-      "Requirements": [
-        "cli",
-        "clipr",
-        "crayon",
-        "curl",
-        "desc",
-        "fs",
-        "gert",
-        "gh",
-        "glue",
-        "jsonlite",
-        "lifecycle",
-        "purrr",
-        "rappdirs",
-        "rlang",
-        "rprojroot",
-        "rstudioapi",
-        "whisker",
-        "withr",
-        "yaml"
-      ]
-    },
     "utf8": {
       "Package": "utf8",
       "Version": "1.2.2",
@@ -2202,10 +1937,10 @@
     },
     "vctrs": {
       "Package": "vctrs",
-      "Version": "0.4.1",
+      "Version": "0.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "8b54f22e2a58c4f275479c92ce041a57",
+      "Hash": "95c2573b232eac82df562f9e300f9790",
       "Requirements": [
         "cli",
         "glue",
@@ -2289,14 +2024,6 @@
         "withr"
       ]
     },
-    "whisker": {
-      "Package": "whisker",
-      "Version": "0.4",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "ca970b96d894e90397ed20637a0c1bbe",
-      "Requirements": []
-    },
     "withr": {
       "Package": "withr",
       "Version": "2.5.0",
@@ -2320,16 +2047,6 @@
       "Repository": "CRAN",
       "Hash": "40682ed6a969ea5abfd351eb67833adc",
       "Requirements": []
-    },
-    "xopen": {
-      "Package": "xopen",
-      "Version": "1.0.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "6c85f015dee9cc7710ddd20f86881f58",
-      "Requirements": [
-        "processx"
-      ]
     },
     "xtable": {
       "Package": "xtable",
@@ -2367,10 +2084,10 @@
     },
     "zoo": {
       "Package": "zoo",
-      "Version": "1.8-10",
+      "Version": "1.8-9",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "277b8b4c5b7b47e664aebfe024a2092e",
+      "Hash": "035d1c7c12593038c26fb1c2fd40c4d2",
       "Requirements": [
         "lattice"
       ]

--- a/server.R
+++ b/server.R
@@ -143,19 +143,19 @@ server <- function(input, output, session) {
     stat_hq %>%
       filter(Region == input$region &
         Sector == input$sector) %>%
-    mutate(Level = case_when(
-          Level_order == "Below level 2" ~ "Below level 2 (GCSE grades 1-3)",
-          Level_order == "Level 2" ~ "Level 2 (GCSE grades 4-9)",
-          Level_order == "Level 3" ~ "Level 3 (GCE A level)",
-          Level_order == "Level 4/5" ~ "Level 4/5 (HNC or HND)",
-          Level_order == "Level 6" ~ "Level 6 (Degree)",
-          TRUE ~ "Level 7 (Master's degree)"
-        )) 
+      mutate(Level = case_when(
+        Level_order == "Below level 2" ~ "Below level 2 (GCSE grades 1-3)",
+        Level_order == "Level 2" ~ "Level 2 (GCSE grades 4-9)",
+        Level_order == "Level 3" ~ "Level 3 (GCE A level)",
+        Level_order == "Level 4/5" ~ "Level 4/5 (HNC or HND)",
+        Level_order == "Level 6" ~ "Level 6 (Degree)",
+        TRUE ~ "Level 7 (Master's degree)"
+      ))
   })
 
   highestQualVolMedianChart <- reactive({
     if (input$showMedian == "Percentage") {
-      selection() %>% 
+      selection() %>%
         ggplot(aes(
           x = Level,
           text = paste(paste0("Percentage: ", formatC(perc_hq * 100,
@@ -194,7 +194,7 @@ server <- function(input, output, session) {
         scale_y_continuous(labels = scales::percent) +
         coord_flip()
     } else {
-      selection() %>% 
+      selection() %>%
         ggplot(aes(
           x = Level,
           text = paste(paste0("Percentage: ", formatC(perc_hq * 100,

--- a/server.R
+++ b/server.R
@@ -149,7 +149,7 @@ server <- function(input, output, session) {
         Level_order == "Level 3" ~ "Level 3 (GCE A level)",
         Level_order == "Level 4/5" ~ "Level 4/5 (HNC or HND)",
         Level_order == "Level 6" ~ "Level 6 (Degree)",
-        TRUE ~ "Level 7 (Master's degree)"
+        TRUE ~ "Level 7+ (Master's degree)"
       ))
   })
 

--- a/tests/shinytest/testUI-current/career-pathways_0.json
+++ b/tests/shinytest/testUI-current/career-pathways_0.json
@@ -1,0 +1,15 @@
+{
+  "input": {
+    "inSelect3": "Level 2",
+    "navbar": "homepage",
+    "qualificationsubject": "Top 20 post-16 qualifications",
+    "region": "England",
+    "regionp": "England",
+    "sector": "Construction",
+    "sectorp": "Construction",
+    "showMedian": "Average earnings"
+  },
+  "output": {
+
+  }
+}

--- a/tests/shinytest/testUI-current/career-pathways_1.json
+++ b/tests/shinytest/testUI-current/career-pathways_1.json
@@ -1,0 +1,51 @@
+{
+  "input": {
+    "inSelect3": "Level 2",
+    "navbar": "overview",
+    "qualificationsubject": "Top 20 post-16 qualifications",
+    "region": "England",
+    "regionp": "England",
+    "sector": "Construction",
+    "sectorp": "Construction",
+    "showMedian": "Average earnings"
+  },
+  "output": {
+    "box2title": "Employee earnings by industry sub-sector and highest level of education",
+    "directionSector": {
+      "html": "<b style=\"font-size:36px; text-align:center; color:\t#ffffff\">-0.6%<\/b>",
+      "deps": [
+
+      ]
+    },
+    "kpiChange": {
+      "html": "<b style=\"font-size: 12px; color: #ffffff\">Projected annual decline in employment in construction in England up to 2027 (Working Futures)<\/b>",
+      "deps": [
+
+      ]
+    },
+    "kpiSector": {
+      "html": "<b style=\"font-size: 12px; color: #ffffff\">Proportion of employees aged 25-30 in England that work in construction<\/b>",
+      "deps": [
+
+      ]
+    },
+    "median_in_sector": {
+      "html": "<b style=\"font-size:36px; text-align:center; color:\t#ffffff\">£20,008.67<\/b>",
+      "deps": [
+
+      ]
+    },
+    "page1title": {
+      "html": "<b style=\"font-size: 24px;\">Construction in England: overview of employee education levels and qualification choices<\/b>",
+      "deps": [
+
+      ]
+    },
+    "perc_in_sector": {
+      "html": "<b style=\"font-size:36px; text-align:center; color:\t#ffffff\">55.6%<\/b>",
+      "deps": [
+
+      ]
+    }
+  }
+}

--- a/tests/shinytest/testUI-current/career-pathways_2.json
+++ b/tests/shinytest/testUI-current/career-pathways_2.json
@@ -1,0 +1,51 @@
+{
+  "input": {
+    "inSelect3": "Level 2",
+    "navbar": "overview",
+    "qualificationsubject": "Top 20 post-16 qualifications",
+    "region": "England",
+    "regionp": "England",
+    "sector": "Construction",
+    "sectorp": "Construction",
+    "showMedian": "Average earnings"
+  },
+  "output": {
+    "box2title": "Employee earnings by industry sub-sector and highest level of education",
+    "directionSector": {
+      "html": "<b style=\"font-size:36px; text-align:center; color:\t#ffffff\">-0.6%<\/b>",
+      "deps": [
+
+      ]
+    },
+    "kpiChange": {
+      "html": "<b style=\"font-size: 12px; color: #ffffff\">Projected annual decline in employment in construction in England up to 2027 (Working Futures)<\/b>",
+      "deps": [
+
+      ]
+    },
+    "kpiSector": {
+      "html": "<b style=\"font-size: 12px; color: #ffffff\">Proportion of employees aged 25-30 in England that work in construction<\/b>",
+      "deps": [
+
+      ]
+    },
+    "median_in_sector": {
+      "html": "<b style=\"font-size:36px; text-align:center; color:\t#ffffff\">£20,008.67<\/b>",
+      "deps": [
+
+      ]
+    },
+    "page1title": {
+      "html": "<b style=\"font-size: 24px;\">Construction in England: overview of employee education levels and qualification choices<\/b>",
+      "deps": [
+
+      ]
+    },
+    "perc_in_sector": {
+      "html": "<b style=\"font-size:36px; text-align:center; color:\t#ffffff\">55.6%<\/b>",
+      "deps": [
+
+      ]
+    }
+  }
+}

--- a/tests/shinytest/testUI-current/career-pathways_3.json
+++ b/tests/shinytest/testUI-current/career-pathways_3.json
@@ -1,0 +1,51 @@
+{
+  "input": {
+    "inSelect3": "Level 2",
+    "navbar": "overview",
+    "qualificationsubject": "Top 20 post-16 qualifications",
+    "region": "England",
+    "regionp": "England",
+    "sector": "Agriculture",
+    "sectorp": "Construction",
+    "showMedian": "Average earnings"
+  },
+  "output": {
+    "box2title": "Employee earnings by industry sub-sector and highest level of education",
+    "directionSector": {
+      "html": "<b style=\"font-size:36px; text-align:center; color:\t#ffffff\">-0.3%<\/b>",
+      "deps": [
+
+      ]
+    },
+    "kpiChange": {
+      "html": "<b style=\"font-size: 12px; color: #ffffff\">Projected annual decline in employment in agriculture in England up to 2027 (Working Futures)<\/b>",
+      "deps": [
+
+      ]
+    },
+    "kpiSector": {
+      "html": "<b style=\"font-size: 12px; color: #ffffff\">Proportion of employees aged 25-30 in England that work in agriculture<\/b>",
+      "deps": [
+
+      ]
+    },
+    "median_in_sector": {
+      "html": "<b style=\"font-size:36px; text-align:center; color:\t#ffffff\">£20,008.88<\/b>",
+      "deps": [
+
+      ]
+    },
+    "page1title": {
+      "html": "<b style=\"font-size: 24px;\">Agriculture in England: overview of employee education levels and qualification choices<\/b>",
+      "deps": [
+
+      ]
+    },
+    "perc_in_sector": {
+      "html": "<b style=\"font-size:36px; text-align:center; color:\t#ffffff\">40.6%<\/b>",
+      "deps": [
+
+      ]
+    }
+  }
+}

--- a/tests/shinytest/testUI-current/career-pathways_4.json
+++ b/tests/shinytest/testUI-current/career-pathways_4.json
@@ -1,0 +1,51 @@
+{
+  "input": {
+    "inSelect3": "Level 2",
+    "navbar": "overview",
+    "qualificationsubject": "Top 20 post-16 qualifications",
+    "region": "North East",
+    "regionp": "England",
+    "sector": "Agriculture",
+    "sectorp": "Construction",
+    "showMedian": "Average earnings"
+  },
+  "output": {
+    "box2title": "Employee earnings by industry sub-sector and highest level of education",
+    "directionSector": {
+      "html": "<b style=\"font-size:36px; text-align:center; color:\t#ffffff\">0.2%<\/b>",
+      "deps": [
+
+      ]
+    },
+    "kpiChange": {
+      "html": "<b style=\"font-size: 12px; color: #ffffff\">Projected annual growth in employment in agriculture in the North East up to 2027 (Working Futures)<\/b>",
+      "deps": [
+
+      ]
+    },
+    "kpiSector": {
+      "html": "<b style=\"font-size: 12px; color: #ffffff\">Proportion of employees aged 25-30 in the North East that work in agriculture<\/b>",
+      "deps": [
+
+      ]
+    },
+    "median_in_sector": {
+      "html": "<b style=\"font-size:36px; text-align:center; color:\t#ffffff\">£19,988.19<\/b>",
+      "deps": [
+
+      ]
+    },
+    "page1title": {
+      "html": "<b style=\"font-size: 24px;\">Agriculture in the North East: overview of employee education levels and qualification choices<\/b>",
+      "deps": [
+
+      ]
+    },
+    "perc_in_sector": {
+      "html": "<b style=\"font-size:36px; text-align:center; color:\t#ffffff\">50.1%<\/b>",
+      "deps": [
+
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Pull request overview

This is to fix labels on the chart with highest qualification data earnings, as they were out-of-sync. I created a column with new labels and that is on the plot now instead of having an independent vector. There is an update to statement about postcode on homepage. The title for pathways chart is changed now to show the value from input selector rather than data. 

## Pull request checklist

Please check if your PR fulfils the following:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been run locally and are passing (`run_tests_locally()`)
- [x] Code is styled according to tidyverse styling (checked locally with `tidy_code()`)


## What is the current behaviour?

Currently labels on highest qualification chart come up out of sync if there are fewer levels than 5 displayed. This is because they come from independent vector not linked to data so I created a column in the data to be displayed on the axis. Also I changed the interactive element from pathway chart to input selector so it will always be displayed. 

## What is the new behaviour?

There are no out-of-sync labels on highest qual chart and there are no errors in the title for the pathway chart. 
